### PR TITLE
Fix to use decimal references if they are shorter

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "character-entities-html4": "^1.0.0",
     "character-entities-legacy": "^1.0.0",
     "is-alphanumerical": "^1.0.0",
+    "is-decimal": "^1.0.2",
     "is-hexadecimal": "^1.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -37,9 +37,20 @@ test('stringifyEntities(value[, options])', function(t) {
   )
 
   t.equal(
-    stringify('alpha © bravo ≠ charlie 𝌆 delta', {useShortestReferences: true}),
-    'alpha &#xA9; bravo &ne; charlie &#x1D306; delta',
+    stringify('alpha © bravo ≠ charlie 𝌆 delta " echo', {
+      useShortestReferences: true
+    }),
+    'alpha &#xA9; bravo &ne; charlie &#x1D306; delta &#34; echo',
     'Should use shortest entities if `useShortestReferences`'
+  )
+
+  t.equal(
+    stringify('" "0 "a "z µ µ0 µa µz', {
+      useShortestReferences: true,
+      omitOptionalSemicolons: true
+    }),
+    '&#34 &#34;0 &#34a &#34z &#xB5 &#xB5;0 &#181a &#xB5z',
+    'Should pick the shortest numeric reference based on `next` with `omitOptionalSemicolons`'
   )
 
   t.equal(


### PR DESCRIPTION
Previously, in cases such as where a double quote (`"`) was encoded,
and the shortest reference was requested, a hexadecimal reference
was produced even though decimal references would be shorter.

Closes GH-5.