### PR TITLE
Refactor to improve performance w/ weak map, hoisted regex

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1,6 +1,6 @@
 /**
  * @typedef CoreOptions
- * @property {Array<string>} [subset=[]]
+ * @property {ReadonlyArray<string>} [subset=[]]
  *   Whether to only escape the given subset of characters.
  * @property {boolean} [escapeOnly=false]
  *   Whether to only escape possibly dangerous characters.
@@ -15,11 +15,12 @@
 
 const defaultSubsetRegex = /["&'<>`]/g
 const surrogatePairsRegex = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g
-// eslint-disable-next-line no-control-regex, unicorn/no-hex-escape
-const controlCharactersRegex = /[\x01-\t\v\f\x0E-\x1F\x7F\x81\x8D\x8F\x90\x9D\xA0-\uFFFF]/g
+const controlCharactersRegex =
+  // eslint-disable-next-line no-control-regex, unicorn/no-hex-escape
+  /[\x01-\t\v\f\x0E-\x1F\x7F\x81\x8D\x8F\x90\x9D\xA0-\uFFFF]/g
 const regexEscapeRegex = /[|\\{}()[\]^$+*?.]/g
 
-/** @type {WeakMap<string[], RegExp>} */
+/** @type {WeakMap<ReadonlyArray<string>, RegExp>} */
 const subsetToRegexCache = new WeakMap()
 
 /**
@@ -32,7 +33,7 @@ const subsetToRegexCache = new WeakMap()
 export function core(value, options) {
   value = value.replace(
     options.subset
-      ? charactersToExpression(options.subset)
+      ? charactersToExpressionCached(options.subset)
       : defaultSubsetRegex,
     basic
   )
@@ -81,13 +82,29 @@ export function core(value, options) {
 }
 
 /**
- * @param {Array<string>} subset
+ * A wrapper function that caches the result of `charactersToExpression` with a WeakMap.
+ * This can improve performance when tooling calls `charactersToExpression` repeatedly
+ * with the same subset.
+ *
+ * @param {ReadonlyArray<string>} subset
+ * @returns {RegExp}
+ */
+function charactersToExpressionCached(subset) {
+  let cached = subsetToRegexCache.get(subset)
+
+  if (!cached) {
+    cached = charactersToExpression(subset)
+    subsetToRegexCache.set(subset, cached)
+  }
+
+  return cached
+}
+
+/**
+ * @param {ReadonlyArray<string>} subset
  * @returns {RegExp}
  */
 function charactersToExpression(subset) {
-  const cached = subsetToRegexCache.get(subset)
-  if (cached) return cached
-
   /** @type {Array<string>} */
   const groups = []
   let index = -1
@@ -96,7 +113,5 @@ function charactersToExpression(subset) {
     groups.push(subset[index].replace(regexEscapeRegex, '\\$&'))
   }
 
-  const regex = new RegExp('(?:' + groups.join('|') + ')', 'g')
-  subsetToRegexCache.set(subset, regex)
-  return regex
+  return new RegExp('(?:' + groups.join('|') + ')', 'g')
 }

--- a/lib/core.js
+++ b/lib/core.js
@@ -13,6 +13,15 @@
  * @typedef {CoreOptions & FormatOptions & import('./util/format-smart.js').FormatSmartOptions} CoreWithFormatOptions
  */
 
+const defaultSubsetRegex = /["&'<>`]/g
+const surrogatePairsRegex = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g
+// eslint-disable-next-line no-control-regex, unicorn/no-hex-escape
+const controlCharactersRegex = /[\x01-\t\v\f\x0E-\x1F\x7F\x81\x8D\x8F\x90\x9D\xA0-\uFFFF]/g
+const regexEscapeRegex = /[|\\{}()[\]^$+*?.]/g
+
+/** @type {WeakMap<string[], RegExp>} */
+const subsetToRegexCache = new WeakMap()
+
 /**
  * Encode certain characters in `value`.
  *
@@ -22,7 +31,9 @@
  */
 export function core(value, options) {
   value = value.replace(
-    options.subset ? charactersToExpression(options.subset) : /["&'<>`]/g,
+    options.subset
+      ? charactersToExpression(options.subset)
+      : defaultSubsetRegex,
     basic
   )
 
@@ -33,14 +44,10 @@ export function core(value, options) {
   return (
     value
       // Surrogate pairs.
-      .replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, surrogate)
+      .replace(surrogatePairsRegex, surrogate)
       // BMP control characters (C0 except for LF, CR, SP; DEL; and some more
       // non-ASCII ones).
-      .replace(
-        // eslint-disable-next-line no-control-regex, unicorn/no-hex-escape
-        /[\x01-\t\v\f\x0E-\x1F\x7F\x81\x8D\x8F\x90\x9D\xA0-\uFFFF]/g,
-        basic
-      )
+      .replace(controlCharactersRegex, basic)
   )
 
   /**
@@ -78,13 +85,18 @@ export function core(value, options) {
  * @returns {RegExp}
  */
 function charactersToExpression(subset) {
+  const cached = subsetToRegexCache.get(subset)
+  if (cached) return cached
+
   /** @type {Array<string>} */
   const groups = []
   let index = -1
 
   while (++index < subset.length) {
-    groups.push(subset[index].replace(/[|\\{}()[\]^$+*?.]/g, '\\$&'))
+    groups.push(subset[index].replace(regexEscapeRegex, '\\$&'))
   }
 
-  return new RegExp('(?:' + groups.join('|') + ')', 'g')
+  const regex = new RegExp('(?:' + groups.join('|') + ')', 'g')
+  subsetToRegexCache.set(subset, regex)
+  return regex
 }

--- a/lib/util/to-decimal.js
+++ b/lib/util/to-decimal.js
@@ -1,3 +1,5 @@
+const decimalRegex = /\d/
+
 /**
  * Configurable ways to encode characters as decimal references.
  *
@@ -8,7 +10,7 @@
  */
 export function toDecimal(code, next, omit) {
   const value = '&#' + String(code)
-  return omit && next && !/\d/.test(String.fromCharCode(next))
+  return omit && next && !decimalRegex.test(String.fromCharCode(next))
     ? value
     : value + ';'
 }

--- a/lib/util/to-hexadecimal.js
+++ b/lib/util/to-hexadecimal.js
@@ -1,3 +1,5 @@
+const hexadecimalRegex = /[\dA-Fa-f]/
+
 /**
  * Configurable ways to encode characters as hexadecimal references.
  *
@@ -8,7 +10,7 @@
  */
 export function toHexadecimal(code, next, omit) {
   const value = '&#x' + code.toString(16).toUpperCase()
-  return omit && next && !/[\dA-Fa-f]/.test(String.fromCharCode(next))
+  return omit && next && !hexadecimalRegex.test(String.fromCharCode(next))
     ? value
     : value + ';'
 }

--- a/lib/util/to-named.js
+++ b/lib/util/to-named.js
@@ -20,6 +20,8 @@ for (key in characterEntitiesHtml4) {
   }
 }
 
+const notAlphanumericRegex = /[^\dA-Za-z]/
+
 /**
  * Configurable ways to encode characters as named references.
  *
@@ -43,7 +45,7 @@ export function toNamed(code, next, omit, attribute) {
       (!attribute ||
         (next &&
           next !== 61 /* `=` */ &&
-          /[^\da-z]/i.test(String.fromCharCode(next))))
+          notAlphanumericRegex.test(String.fromCharCode(next))))
     ) {
       return value
     }


### PR DESCRIPTION
- This PR hoists regexes as top-level variables to prevent constantly creating them.
- It also implements caching for `charactersToExpression` to prevent repeatedly created regexes dynamically.

### Benchmark

During my benchmarking of a project using `toHtml` heavily from `hast-util-to-html`, `toHtml` took about 6.06s in execution time. This PR drops it to 2.38s. `toHtml` uses this package which is hot code during its `serializeAttribute` call. Examples: https://github.com/search?q=repo%3Asyntax-tree%2Fhast-util-to-html%20subset%3A&type=code

### Notes on caching

The WeakMap caching for `charactersToExpression` means that if the array is mutated, the regex won't be re-built but I think this is a fine caveat that shouldn't be relied upon. If I remove the WeakMap caching, the benchmark only drops to 5.52s.

In `hast-util-to-html`, there are two places (`lib/handle/text.js` and `lib/handle/comment.js`) that can yet to take advantage of the caching. If this PR is accepted, I can update `hast-util-to-html` to do so, and I expect another 1s savings, bringing down to around 1.4s for `toHtml`.